### PR TITLE
chore: add SyncSecretsDry flag to skip secrets sync in prod deployments

### DIFF
--- a/internal/actions/deploy/env.go
+++ b/internal/actions/deploy/env.go
@@ -8,6 +8,7 @@ const profilePrefix = "draftea-"
 type EnvConfig struct {
 	Profile        string // e.g. "draftea-dev", "draftea-prod", "draftea-feature"
 	ExtraSLSParams string // non-empty only for feature: --param="stage=feature"
+	SyncSecretsDry bool   // if true, sets SLS_SYNC_SECRETS_DRY=true to skip secrets sync
 }
 
 // Stage derives the stage name from the profile by stripping the profilePrefix.
@@ -21,7 +22,8 @@ var (
 	}
 
 	ProdEnv = EnvConfig{
-		Profile: profilePrefix + "prod",
+		Profile:        profilePrefix + "prod",
+		SyncSecretsDry: true,
 	}
 
 	FeatureEnv = EnvConfig{

--- a/internal/actions/deploy/function.go
+++ b/internal/actions/deploy/function.go
@@ -48,10 +48,15 @@ func DeployFunction(env EnvConfig, serviceArg string, functionNames []string) er
 		}
 	}
 
+	syncSecretsDry := "false"
+	if env.SyncSecretsDry {
+		syncSecretsDry = "true"
+	}
+
 	log.Info("Packaging service...")
 	packageScript := fmt.Sprintf(
-		`cd %q && env STAGE=%s AWS_ACCOUNT=%s sls package --stage %s --verbose --aws-profile %s`,
-		absPath, stage, accountID, stage, env.Profile,
+		`cd %q && env STAGE=%s AWS_ACCOUNT=%s SLS_SYNC_SECRETS_DRY=%s sls package --stage %s --verbose --aws-profile %s`,
+		absPath, stage, accountID, syncSecretsDry, stage, env.Profile,
 	)
 	if _, err := exec.Command(packageScript, exec.WithStdout(os.Stdout), exec.WithStderr(os.Stderr)); err != nil {
 		return fmt.Errorf("sls package failed: %w", err)

--- a/internal/actions/deploy/service.go
+++ b/internal/actions/deploy/service.go
@@ -63,9 +63,14 @@ func deployServiceToDir(env EnvConfig, absPath, accountID string) error {
 		slsParams = fmt.Sprintf("%s %s", slsParams, env.ExtraSLSParams)
 	}
 
+	syncSecretsDry := "false"
+	if env.SyncSecretsDry {
+		syncSecretsDry = "true"
+	}
+
 	script := fmt.Sprintf(
-		`cd %q && npm install && env STAGE=%s AWS_ACCOUNT=%s SLS_PARAMS=%q npm run deploy`,
-		absPath, stage, accountID, slsParams,
+		`cd %q && npm install && env STAGE=%s AWS_ACCOUNT=%s SLS_PARAMS=%q SLS_SYNC_SECRETS_DRY=%s npm run deploy`,
+		absPath, stage, accountID, slsParams, syncSecretsDry,
 	)
 
 	_, err = exec.Command(script, exec.WithStdout(os.Stdout), exec.WithStderr(os.Stderr))


### PR DESCRIPTION
## Description

Se agrega el campo SyncSecretsDry en EnvConfig para controlar la variable de entorno SLS_SYNC_SECRETS_DRY                                                                                           
  - SyncSecretsDry: true en ProdEnv para que los deploys a prod desde local siempre omitan la sincronización de secrets                                                                                     

Motivacion: los users no cuentan con permisos para hacer update de secrets en AWS Secrets Manager, por lo que se presenta el siguiente error al hacer deploy:

`User: arn:aws:iam::776658659836:user/<username> is not authorized to perform: secretsmanager:UpdateSecret on resource: <resource> because no identity-based policy allows the secretsmanager:UpdateSecret action`
