### PR TITLE
fix: wait for final postgres server

### DIFF
--- a/internal/actions/local/setup/init.go
+++ b/internal/actions/local/setup/init.go
@@ -48,7 +48,7 @@ func (a *Action) init() error {
 func (a *Action) postgresHealthCheck() error {
 	log.Debug("postgres health check")
 
-	cmd := "docker exec -i api-local-postgres pg_isready -U root"
+	cmd := "docker exec -i api-local-postgres pg_isready -h 127.0.0.1 -U root"
 
 	maxTries := 5
 


### PR DESCRIPTION
## Description

Make the local PostgreSQL readiness check use TCP instead of the default Unix socket. This prevents `draft local:setup --prune` from treating PostgreSQL's temporary bootstrap server as fully initialized.

## Task Context

### What is the current behavior?

`pg_isready -U root` can succeed against the temporary Unix-socket server used by the official PostgreSQL entrypoint. Draft can then execute database initialization concurrently with the entrypoint, intermittently causing duplicate database creation, exit status 137, and connection-refused migration failures.

Current behavior has been [reported](https://draftea-pitaco.slack.com/archives/C0BC4KRSF1V/p1782493539463389?thread_ts=1782493382.990659&cid=C0BC4KRSF1V) to produce errors 3/10 times and produces errors like

```
DETAIL:  Key (datname)=(games_core_test) already exists., exit status 137
Executing 'up' migration for 'stats'
error: failed to open database: dial tcp [::1]:5432: connect: connection refused
[ERROR] failed to setup test environment: migrate up failed: failed to execute 'up' migration on all databases: exec: migrate -source file:///Users/bentoper/Documents/draftea/api/migrations/stats -database postgres://root:root@localhost:5432/stats?sslmode=disable up [code 1]: error: failed to open database: dial tcp [::1]:5432: connect: connection refused, exit status 1
```

### What is the new behavior?

Draft checks `127.0.0.1`, which becomes available only when the final PostgreSQL server is listening on TCP. Database initialization and migrations therefore begin after entrypoint initialization completes.


### How it Was tested

Validated against the Draftea API repository with 10 consecutive `draft local:setup --prune` runs. All 10 succeeded with zero exit-137, connection-refused, or duplicate-database errors. The Draft lint task also passed (with only pre-existing warnings).

